### PR TITLE
Attributes on their own line can fail with partial files.

### DIFF
--- a/IntelliTect.Analyzer/IntelliTect.Analyzer.Test/AttributesOnSeparateLinesTests.cs
+++ b/IntelliTect.Analyzer/IntelliTect.Analyzer.Test/AttributesOnSeparateLinesTests.cs
@@ -64,6 +64,66 @@ namespace ConsoleApp
         }
 
         [TestMethod]
+        public void ClassAttribute_SymbolDeclaredOnSameLineAsAttributeInPartial_NoDiagnosticInformationReturned()
+        {
+            string test = @"using System;
+namespace ConsoleApp
+{
+    [A(Foo = ""Foo"", Bar = ""Bar"")]
+    class Program
+    {
+        [A(Foo = ""Foo"", Bar = ""Bar"")]
+        static void Main()
+        {
+        }
+    }
+
+    class AAttribute : Attribute
+    {
+        public string Foo { get; set; }
+        public string Bar { get; set; }
+    }
+}";
+
+            string test2 = @"using System;
+namespace ConsoleApp
+{
+    partial class Program
+    {
+    }
+}";
+            //Testing both here because the order the files are loaded changes
+            //the order that location information from the Program symbol is returned.
+            VerifyCSharpDiagnostic(new[] { test2, test });
+            VerifyCSharpDiagnostic(new[] { test, test2 });
+        }
+
+        [TestMethod]
+        public void ClassAttribute_DeclaredOnPartialSymbolInTheSameFile_Warning()
+        {
+            string test = @"using System;
+namespace ConsoleApp
+{
+    class Program
+    {
+        [A(Foo = ""Foo"", Bar = ""Bar"")]
+        static void Main()
+        {
+        }
+    }
+
+    [A] partial class Program
+    {
+    }
+    class AAttribute : Attribute
+    {
+    }
+}";
+
+            VerifyCSharpDiagnostic(test, GetExpectedDiagnosticResult(12, 6));
+        }
+
+        [TestMethod]
         public void MethodAttributeLineViolation_TwoAttributesOnSameLine_Warning()
         {
             string test = @"using System;

--- a/IntelliTect.Analyzer/IntelliTect.Analyzer/CodeFixes/AttributesOnSeparateLines.cs
+++ b/IntelliTect.Analyzer/IntelliTect.Analyzer/CodeFixes/AttributesOnSeparateLines.cs
@@ -65,7 +65,7 @@ namespace IntelliTect.Analyzer.CodeFixes
             {
                 attributeLists = attributeLists.Add(
                     SyntaxFactory.AttributeList(
-                        SyntaxFactory.SeparatedList<AttributeSyntax>(
+                        SyntaxFactory.SeparatedList(
                             new[] {
                                     SyntaxFactory.Attribute(
                                         attribute.Name,
@@ -86,36 +86,26 @@ namespace IntelliTect.Analyzer.CodeFixes
 
         private static IEnumerable<AttributeListSyntax> GetAttributeListSyntaxes(SyntaxNode node)
         {
-            switch (node)
+            return node switch
             {
-                case ClassDeclarationSyntax c:
-                    return c.AttributeLists;
-                case MethodDeclarationSyntax m:
-                    return m.AttributeLists;
-                case PropertyDeclarationSyntax p:
-                    return p.AttributeLists;
-                case FieldDeclarationSyntax f:
-                    return f.AttributeLists;
-                default:
-                    throw new NotImplementedException();
-            }
+                ClassDeclarationSyntax c => c.AttributeLists,
+                MethodDeclarationSyntax m => m.AttributeLists,
+                PropertyDeclarationSyntax p => p.AttributeLists,
+                FieldDeclarationSyntax f => f.AttributeLists,
+                _ => throw new NotImplementedException(),
+            };
         }
 
         private static SyntaxNode BuildNodeWithAttributeLists(SyntaxNode node, SyntaxList<AttributeListSyntax> attributeLists)
         {
-            switch (node)
+            return node switch
             {
-                case ClassDeclarationSyntax c:
-                    return c.WithAttributeLists(attributeLists);
-                case MethodDeclarationSyntax m:
-                    return m.WithAttributeLists(attributeLists);
-                case PropertyDeclarationSyntax p:
-                    return p.WithAttributeLists(attributeLists);
-                case FieldDeclarationSyntax f:
-                    return f.WithAttributeLists(attributeLists);
-                default:
-                    throw new NotImplementedException();
-            }
+                ClassDeclarationSyntax c => c.WithAttributeLists(attributeLists),
+                MethodDeclarationSyntax m => m.WithAttributeLists(attributeLists),
+                PropertyDeclarationSyntax p => p.WithAttributeLists(attributeLists),
+                FieldDeclarationSyntax f => f.WithAttributeLists(attributeLists),
+                _ => throw new NotImplementedException(),
+            };
         }
     }
 }


### PR DESCRIPTION
When the attribute's line number matches that of the symbol in a partial it errors.

In this case the error would falsely be reported when the attributes was on the same line as the symbol declared in a partial file. In this case the symbol has more than one location. Rather than always just using the first symbol location, we will now use all symbol locations in the same file.