### PR TITLE
Issue #86: Change 'Standards' to 'Guidelines' and fix readmes build b…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![NuGet Status](http://img.shields.io/nuget/v/IntelliTect.Analyzers.svg?style=flat&label=IntelliTect.Analyzers)](https://www.nuget.org/packages/IntelliTect.Analyzers/)
 
-[![Build Status](https://intellitect.visualstudio.com/CodingStandards/_apis/build/status/IntelliTect.CodingStandards?branchName=master)](https://intellitect.visualstudio.com/CodingStandards/_build/latest?definitionId=76&branchName=master)
+[![Build Status](https://intellitect.visualstudio.com/CodingStandards/_apis/build/status/IntelliTect.CodingGuidelines?branchName=master)](https://intellitect.visualstudio.com/CodingStandards/_build/latest?definitionId=95&branchName=master)
 
 [Coding Snippets Repository](https://github.com/IntelliTect/IntelliTect.Snippets)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,12 @@
 ---
-title: Design Standards
+title: Design GuideLines
 ---
 
-Coding Standards
+Coding Guidelines
 ================
 * [C#]({{ site.baseurl }}{% link coding/csharp.md %})
 
-Design Standards
+Design Guidelines
 ================
 
 * [Databases]({{ site.baseurl }}{% link databases/index.md %})


### PR DESCRIPTION
Closes #86

Looking at the [previous](https://intellitect.visualstudio.com/CodingStandards/_build/latest?definitionId=76&branchName=master) readme build badge I noticed that it was redirecting to a build from march. After renaming the repository the correct link became https://intellitect.visualstudio.com/CodingStandards/_build/latest?definitionId=95&branchName=master, so I changed to it.