### PR TITLE
chore: Add ruby to dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+- package-ecosystem: "bundler"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This is just because I see a ton of things in this tab: https://github.com/IntelliTect/CodingGuidelines/security/dependabotf and it makes me think maybe we just want to keep the ruby deps up to date if possible.

Thoughts?